### PR TITLE
Add gfm-mode (GitHub Flavored Markdown files) as a new folding backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# kirigami.el - A Unified Interface for Text Folding across a diverse set of Emacs modes (`outline-mode`, `outline-minor-mode`, `outline-indent-mode`, `org-mode`, `markdown-mode`, `vdiff-mode`, `hs-minor-mode`, `treesit-fold-mode`...)
+# kirigami.el - A Unified Interface for Text Folding across a diverse set of Emacs modes (`outline-mode`, `outline-minor-mode`, `outline-indent-mode`, `org-mode`, `markdown-mode`, `gfm-mode`, `vdiff-mode`, `hs-minor-mode`, `treesit-fold-mode`...)
 ![Build Status](https://github.com/jamescherti/kirigami.el/actions/workflows/ci.yml/badge.svg)
 ![License](https://img.shields.io/github/license/jamescherti/kirigami.el)
 ![](https://raw.githubusercontent.com/jamescherti/kirigami.el/main/.images/made-for-gnu-emacs.svg)
 
-The **kirigami** Emacs package offers a **unified interface for opening and closing folds** across a diverse set of major and minor modes in Emacs, including `outline-mode`, `outline-minor-mode`, `outline-indent-mode`, `org-mode`, `markdown-mode`, `vdiff-mode`, `vdiff-3way-mode`, `hs-minor-mode`, `hide-ifdef-mode`, `origami-mode`, `yafolding-mode`, `folding-mode`, and `treesit-fold-mode`.
+The **kirigami** Emacs package offers a **unified interface for opening and closing folds** across a diverse set of major and minor modes in Emacs, including `outline-mode`, `outline-minor-mode`, `outline-indent-mode`, `org-mode`, `markdown-mode`, `gfm-mode`, `vdiff-mode`, `vdiff-3way-mode`, `hs-minor-mode`, `hide-ifdef-mode`, `origami-mode`, `yafolding-mode`, `folding-mode`, and `treesit-fold-mode`.
 
 With Kirigami, folding key bindings only need to be configured **once**. After that, the same keys work consistently across all supported major and minor modes, providing a unified and predictable experience for opening and closing folds. The available commands include:
 
@@ -16,7 +16,7 @@ With Kirigami, folding key bindings only need to be configured **once**. After t
 
 If **kirigami** enhances your workflow, please show your support by **⭐ starring kirigami.el on GitHub** to help more Emacs users discover its benefits.
 
-(In addition to unified interface for opening and closing folds, the **kirigami** package enhances folding behavior in `outline-mode`, `outline-minor-mode`, `markdown-mode`, and `org-mode`. It ensures that deep folds open reliably and allows folds to be closed even when the cursor is positioned inside the content.)
+(In addition to unified interface for opening and closing folds, the **kirigami** package enhances folding behavior in `outline-mode`, `outline-minor-mode`, `markdown-mode`, `gfm-mode`, and `org-mode`. It ensures that deep folds open reliably and allows folds to be closed even when the cursor is positioned inside the content.)
 
 ## Features
 
@@ -28,13 +28,13 @@ Here are the features that **kirigami** offers:
   * `outline-mode`, `outline-minor-mode`
   * `outline-indent-mode` ([outline-indent.el](https://github.com/jamescherti/outline-indent.el), a package that enables code folding based on indentation)
   * `org-mode`
-  * `markdown-mode`
+  * `markdown-mode` and `gfm-mode`
   * `vdiff-mode` and `vdiff-3way-mode`
   * `hs-minor-mode`
   * `hide-ifdef-mode`
   * `origami-mode`
   * `treesit-fold-mode`
-* In addition to unified interface, the kirigami package enhances folding behavior in `outline-mode`, `outline-minor-mode`, `markdown-mode`, and `org-mode`. It ensures that deep folds open reliably and allows folds to be closed even when the cursor is positioned inside the content. Additionally, it resolves upstream Emacs issues, such as [bug#79286](https://lists.gnu.org/archive/html/bug-gnu-emacs/2025-08/msg01128.html).
+* In addition to unified interface, the kirigami package enhances folding behavior in `outline-mode`, `outline-minor-mode`, `markdown-mode`, `gfm-mode`, and `org-mode`. It ensures that deep folds open reliably and allows folds to be closed even when the cursor is positioned inside the content. Additionally, it resolves upstream Emacs issues, such as [bug#79286](https://lists.gnu.org/archive/html/bug-gnu-emacs/2025-08/msg01128.html).
 
 The kirigami package supports Emacs version 26.3 and above.
 

--- a/kirigami.el
+++ b/kirigami.el
@@ -187,7 +187,8 @@ specific reason to disable these enhancements."
     ((outline-mode
       outline-minor-mode
       org-mode
-      markdown-mode)
+      markdown-mode
+      gfm-mode)
      :open-all   show-all
      :close-all  ,(lambda ()
                     (when (fboundp 'hide-sublevels)


### PR DESCRIPTION
gfm-mode is used for README.md files written in GitHub Flavored Markdown